### PR TITLE
Add SE_DEBUG Privilege token

### DIFF
--- a/injector/src/main.cpp
+++ b/injector/src/main.cpp
@@ -23,6 +23,8 @@ int main(int argc, char* argv[])
 	auto path = std::filesystem::path(argv[0]).parent_path();
 	current_path(path);
 
+	SetDebugPrivilege();
+
 	WaitForCloseProcess(GlobalGenshinProcName);
 	WaitForCloseProcess(ChinaGenshinProcName);
 

--- a/injector/src/util.cpp
+++ b/injector/src/util.cpp
@@ -57,3 +57,25 @@ void WaitForCloseProcess(const std::string& processName)
     if (hProc != NULL)
         CloseHandle(hProc);
 }
+
+bool SetDebugPrivilege()
+{
+    BOOL result = FALSE;
+    HANDLE hToken = NULL;
+    LUID luid = { 0 };
+
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hToken))
+    {
+        if (LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &luid))
+        {
+            TOKEN_PRIVILEGES tokenPriv = { 0 };
+            tokenPriv.PrivilegeCount = 1;
+            tokenPriv.Privileges[0].Luid = luid;
+            tokenPriv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+            result = AdjustTokenPrivileges(hToken, FALSE, &tokenPriv, sizeof(TOKEN_PRIVILEGES), NULL, NULL);
+        }
+    }
+
+    return result;
+}

--- a/injector/src/util.h
+++ b/injector/src/util.h
@@ -6,3 +6,4 @@
 
 int FindProcessId(const std::string& processName);
 void WaitForCloseProcess(const std::string& processName);
+bool SetDebugPrivilege();


### PR DESCRIPTION
This PR add the SE_DEBUG Privilege token to the injector to match the privileges of the injector if run through Visual Studio,  it does fix an handle error in some conditions

When there is multiple session openned this fix the error 6

This is a know issue, when another user is logged on, the injector fail to run the game, by adding debugprivilege to the injector the issue is now fixed